### PR TITLE
Skip terragrunt-cache dirs

### DIFF
--- a/utils/fileutil/fileutil.go
+++ b/utils/fileutil/fileutil.go
@@ -48,7 +48,7 @@ func ShouldSkipDir(path string, info os.FileInfo) bool {
 	if info == nil {
 		return false
 	}
-	return info.IsDir() && (info.Name() == ".terraform" || info.Name() == ".terragrunt-cache")
+	return info.IsDir() && strings.HasPrefix(info.Name(), ".terra")
 }
 
 // FindFiles recursively or non-recursively finds all valid Terraform and Terragrunt files

--- a/utils/fileutil/fileutil.go
+++ b/utils/fileutil/fileutil.go
@@ -48,7 +48,7 @@ func ShouldSkipDir(path string, info os.FileInfo) bool {
 	if info == nil {
 		return false
 	}
-	return info.IsDir() && info.Name() == ".terraform"
+	return info.IsDir() && (info.Name() == ".terraform" || info.Name() == ".terragrunt-cache")
 }
 
 // FindFiles recursively or non-recursively finds all valid Terraform and Terragrunt files

--- a/utils/fileutil/fileutil_test.go
+++ b/utils/fileutil/fileutil_test.go
@@ -588,3 +588,36 @@ func TestFindFilesEnhancedErrorHandling(t *testing.T) {
 		t.Errorf("Expected 0 files in empty directory, got %d", len(files))
 	}
 }
+
+func TestShouldSkipDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		dirName  string
+		isDir    bool
+		expected bool
+	}{
+		{"skip .terraform directory", ".terraform", true, true},
+		{"skip .terragrunt-cache directory", ".terragrunt-cache", true, true},
+		{"don't skip regular directory", "regular-dir", true, false},
+		{"don't skip file even if named .terraform", ".terraform", false, false},
+		{"don't skip file even if named .terragrunt-cache", ".terragrunt-cache", false, false},
+		{"don't skip src directory", "src", true, false},
+		{"don't skip modules directory", "modules", true, false},
+		{"handle nil info", "any-name", true, false}, // This will be tested with nil info
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var info os.FileInfo
+			if tt.name != "handle nil info" {
+				info = &mockFileInfo{name: tt.dirName, isDir: tt.isDir}
+			}
+			// For "handle nil info" test case, info remains nil
+
+			got := ShouldSkipDir("/some/path/"+tt.dirName, info)
+			if got != tt.expected {
+				t.Errorf("ShouldSkipDir(%q, isDir=%v) = %v, want %v", tt.dirName, tt.isDir, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Title
Skip terragrunt-cache directories

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description
Skip the terragrunt-cache directory. Terragrunt doesn't like its cache changed.

## Testing
Added a test for the skip function.

## Impact
Ignores the terragrunt-cache directory from being parsed.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings 