### PR TITLE
fix release

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run tests
         run: go test ./...
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore(deps): update Go dependencies'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,22 +232,6 @@ jobs:
             dist/checksums.txt
           generate_release_notes: true
           make_latest: ${{ needs.validate.outputs.is_prerelease == 'false' }}
-      - name: Create git tag (manual releases only)
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          VERSION: ${{ needs.validate.outputs.version }}
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if ! git rev-parse "$VERSION" >/dev/null 2>&1; then
-            git tag -a "$VERSION" -m "Release $VERSION"
-            git push origin "$VERSION"
-            echo "✅ Created and pushed tag: $VERSION"
-          else
-            echo "ℹ️  Tag $VERSION already exists"
-          fi
       - name: Release summary
         env:
           VERSION: ${{ needs.validate.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
         with:
           tag_name: ${{ needs.validate.outputs.version }}
-          name: Release ${{ needs.validate.outputs.version }}
+          name: ${{ needs.validate.outputs.version }}
           body: ${{ steps.changelog.outputs.changelog }}
           draft: ${{ github.event.inputs.draft || false }}
           prerelease: ${{ needs.validate.outputs.is_prerelease == 'true' || github.event.inputs.prerelease || false }}


### PR DESCRIPTION
# Pull Request

## Description
Fix release failures on `tag already exists` error

<!-- Briefly describe what changes this PR introduces and why -->

Fixes #<!-- issue number -->

## Changes
<!-- List key changes made in this PR -->
- Remove the step `Create git tag (manual releases only)` because `Create GitHub Release` already creates a tag
-

## Testing
<!-- How have you tested these changes? -->
- [ ] Tests added/updated
- [ ] Manual testing performed
- [ ] All tests passing

## Checklist

- [ ] Code follows project style guidelines
- [X] Self-review completed
- [ ] Documentation updated (if needed)
- [X] No new warnings introduced

<!--
## Screenshots (if applicable)
Add screenshots to help explain your changes
-->
