### PR TITLE
fix(deps): upgrade Go to 1.25.8 to fix GO-2026-4602 vulnerability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 env:
-  GO_VERSION: '1.23.10'
+  GO_VERSION: '1.25.8'
 jobs:
   # ===========================================================================
   # Linting and Code Quality
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.23.x']
+        go-version: ['1.25.x']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -142,7 +142,7 @@ jobs:
           # shellcheck disable=SC2046
           go test -race -short $(go list ./... | grep -v '/integration$')
       - name: Upload unit test coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.23.x'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.x'
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           files: ./coverage.out

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/obergerkatz/sortTF
 
-go 1.23.0
+go 1.25.8
 
 require (
 	github.com/fatih/color v1.18.0


### PR DESCRIPTION
# Pull request overview

## Changes
- Upgrade Go from 1.23.0 to 1.25.8 to fix security vulnerability GO-2026-4602 in `os.ReadDir`
- Update CI workflows to use Go 1.25.8
- All tests pass with new version

## Testing
<!-- How have you tested these changes? -->
- [ ] Tests added/updated
- [ ] Manual testing performed
- [x] All tests passing

## Checklist
<!-- Please review the following checklist before submitting your PR -->
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)
